### PR TITLE
Use textContent instead of innerHTML to extract formula

### DIFF
--- a/math-katex/math-katex.js
+++ b/math-katex/math-katex.js
@@ -312,7 +312,7 @@ window.RevealMath = window.RevealMath || (function() {
 
 		each( wrappedElements, function ( e ) {
 
-			var formula = e.innerHTML;
+			var formula = e.textContent;
 			var offset = 0;    // For error-position correction
 
 			if (e.classList.contains( 'display' )) {


### PR DESCRIPTION
Currently this fails

``` HTML
$$ a > b $$
```

because `innerHTML` is used to extract formula string from the html now. This results in errors when you try to use (for example) inequality signs.

Say we have this html

``` HTML
<div id="foo">a > b</div>
```

then

``` javascript
document.getElementById("foo").innerHTML // a &gt; b
document.getElementById("foo").textContent // a > b
```

KaTeX can't parse the former.

This pull-req tries to solve this by using [textContent instead](https://github.com/Khan/KaTeX/blob/master/contrib/auto-render/auto-render.js#L55).
